### PR TITLE
Remove warnings about deprecated use of M_PI

### DIFF
--- a/KVSpinnerView/AnimationManager.swift
+++ b/KVSpinnerView/AnimationManager.swift
@@ -67,7 +67,7 @@ class AnimationManager: NSObject {
     
     internal func infiniteStrokeRotateAnimation(isOdd: Bool) -> CAAnimation  {
         let animation = CABasicAnimation(keyPath: "transform.rotation")
-       	animation.byValue = isOdd ? M_PI * -2.0 : M_PI * 2.0
+       	animation.byValue = isOdd ? Double.pi * -2.0 : Double.pi * 2.0
         
         let group = CAAnimationGroup()
         group.beginTime = 0.5

--- a/KVSpinnerView/Layers/CircleLayer.swift
+++ b/KVSpinnerView/Layers/CircleLayer.swift
@@ -33,10 +33,10 @@ class CircleLayer: CAShapeLayer {
         let radius = KVSpinnerView.settings.spinnerRadius
         let linesDistance = radius / 5
         
-        let startEvenAngle = CGFloat(-M_PI_2)
-        let endEvenAngle = startEvenAngle + CGFloat(M_PI * 2)
+        let startEvenAngle = CGFloat(-Double.pi/2)
+        let endEvenAngle = startEvenAngle + CGFloat(Double.pi * 2)
         let startOddAngle = CGFloat(0)
-        let endOddAngle = startOddAngle + CGFloat(M_PI * 2)
+        let endOddAngle = startOddAngle + CGFloat(Double.pi * 2)
         
         let isIndexEven = index % 2 == 1
         let path = UIBezierPath(


### PR DESCRIPTION
I substituted "M_PI" by "Double.pi" instead.